### PR TITLE
Make andor camera return correct type for preview buffer, unify

### DIFF
--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.cpp
@@ -156,7 +156,7 @@ void Brillouin::acquire(std::unique_ptr <StorageWrapper> & storage) {
 				POINT3 newPosition{ positionsX[ll], positionsY[ll], positionsZ[ll] };
 				(*m_scanControl)->setPosition(newPosition);
 
-				std::vector<AT_U8> images(bytesPerFrame * m_settings.camera.frameCount);
+				std::vector<unsigned short> images(bytesPerFrame * m_settings.camera.frameCount);
 
 				for (gsl::index mm = 0; mm < m_settings.camera.frameCount; mm++) {
 					if (m_abort) {
@@ -238,7 +238,7 @@ void Brillouin::calibrate(std::unique_ptr <StorageWrapper> & storage) {
 	hsize_t dims_cal[3] = { m_settings.nrCalibrationImages, m_settings.camera.roi.height, m_settings.camera.roi.width };
 
 	int bytesPerFrame = m_settings.camera.roi.width * m_settings.camera.roi.height * 2;
-	std::vector<AT_U8> images((int64_t)bytesPerFrame * m_settings.nrCalibrationImages);
+	std::vector<unsigned short> images((int64_t)bytesPerFrame * m_settings.nrCalibrationImages);
 	for (gsl::index mm = 0; mm < m_settings.nrCalibrationImages; mm++) {
 		if (m_abort) {
 			this->abortMode();

--- a/BrillouinAcquisition/src/BrillouinAcquisition.h
+++ b/BrillouinAcquisition/src/BrillouinAcquisition.h
@@ -74,7 +74,10 @@ Q_DECLARE_METATYPE(ODT_SETTING);
 Q_DECLARE_METATYPE(ODT_SETTINGS);
 Q_DECLARE_METATYPE(ODTIMAGE*);
 Q_DECLARE_METATYPE(FLUOIMAGE*);
-Q_DECLARE_METATYPE(FLUORESCENCE_SETTINGS*);
+Q_DECLARE_METATYPE(FLUORESCENCE_SETTINGS);
+Q_DECLARE_METATYPE(PreviewBuffer<unsigned short>*);
+Q_DECLARE_METATYPE(PreviewBuffer<unsigned char>*);
+Q_DECLARE_METATYPE(bool*);
 
 class BrillouinAcquisition : public QMainWindow {
 	Q_OBJECT
@@ -130,8 +133,10 @@ private slots:
 	void microscopeElementPositionsChanged(std::vector<int>);
 	void microscopeElementPositionChanged(DeviceElement element, int position);
 	void on_camera_playPause_clicked();
-	void onNewImage();
-	void onNewBrightfieldImage();
+
+	void updateImageBrillouin();
+	void updateImageODT();
+
 	void initializePlot(PLOT_SETTINGS plotSettings);
 
 	void xAxisRangeChangedODT(const QCPRange & newRange);
@@ -308,6 +313,9 @@ private:
 
 	PLOT_SETTINGS m_BrillouinPlot;
 	PLOT_SETTINGS m_ODTPlot;
+
+	template <typename T>
+	void updateImage(PreviewBuffer<T>* previewBuffer, PLOT_SETTINGS *plotSettings);
 
 	SETTINGS_DEVICES m_deviceSettings;
 	CAMERA_OPTIONS m_cameraOptions;

--- a/BrillouinAcquisition/src/Devices/Camera.h
+++ b/BrillouinAcquisition/src/Devices/Camera.h
@@ -40,6 +40,8 @@ protected:
 	virtual void readOptions() = 0;
 	virtual void readSettings() = 0;
 
+	std::mutex m_mutex;
+
 signals:
 	void settingsChanged(CAMERA_SETTINGS);
 	void optionsChanged(CAMERA_OPTIONS);

--- a/BrillouinAcquisition/src/Devices/PointGrey.h
+++ b/BrillouinAcquisition/src/Devices/PointGrey.h
@@ -25,8 +25,6 @@ private:
 
 	void acquireImage(unsigned char * buffer);
 
-	std::mutex m_mutex;
-
 	/*
 	 * Members and functions inherited from base class
 	 */

--- a/BrillouinAcquisition/src/Devices/andor.cpp
+++ b/BrillouinAcquisition/src/Devices/andor.cpp
@@ -281,7 +281,7 @@ void Andor::cleanupAcquisition() {
 	AT_Flush(m_camera);
 }
 
-void Andor::acquireImage(AT_U8* buffer) {
+void Andor::acquireImage(unsigned short* buffer) {
 	// Pass this buffer to the SDK
 	unsigned char* UserBuffer = new unsigned char[m_bufferSize];
 	AT_QueueBuffer(m_camera, UserBuffer, m_bufferSize);
@@ -303,7 +303,7 @@ void Andor::acquireImage(AT_U8* buffer) {
 	AT_GetInt(m_camera, L"AOIWidth", &m_settings.roi.width);
 	AT_GetInt(m_camera, L"AOIStride", &m_imageStride);
 
-	AT_ConvertBuffer(Buffer, buffer, m_settings.roi.width, m_settings.roi.height, m_imageStride, m_settings.readout.pixelEncoding.c_str(), L"Mono16");
+	AT_ConvertBuffer(Buffer, reinterpret_cast<unsigned char*>(buffer), m_settings.roi.width, m_settings.roi.height, m_imageStride, m_settings.readout.pixelEncoding.c_str(), L"Mono16");
 
 	delete[] Buffer;
 }
@@ -324,7 +324,7 @@ void Andor::getImageForPreview() {
 	}
 }
 
-void Andor::getImageForAcquisition(AT_U8* buffer) {
+void Andor::getImageForAcquisition(unsigned short* buffer) {
 	std::lock_guard<std::mutex> lockGuard(m_mutex);
 	acquireImage(buffer);
 

--- a/BrillouinAcquisition/src/Devices/andor.h
+++ b/BrillouinAcquisition/src/Devices/andor.h
@@ -43,9 +43,7 @@ private:
 	void getEnumString(AT_WC* feature, AT_WC* string);
 	void preparePreview();
 
-	void acquireImage(AT_U8* buffer);
-
-	std::mutex m_mutex;
+	void acquireImage(unsigned short* buffer);
 
 	/*
 	 * Members and functions inherited from base class
@@ -68,7 +66,7 @@ public:
 	void setCalibrationExposureTime(double);
 
 	// preview buffer for live acquisition
-	PreviewBuffer<AT_U8>* m_previewBuffer = new PreviewBuffer<AT_U8>;
+	PreviewBuffer<unsigned short>* m_previewBuffer = new PreviewBuffer<unsigned short>;
 
 private slots:
 	void getImageForPreview();
@@ -98,7 +96,7 @@ public slots:
 	/*
 	 * Unify me
 	 */
-	void getImageForAcquisition(AT_U8* buffer);
+	void getImageForAcquisition(unsigned short* buffer);
 
 signals:
 	void cameraCoolingChanged(bool);


### PR DESCRIPTION
Supersedes #56.

This makes the andor camera return the correct type for the preview buffer, so no reinterpret_cast is necessary on the plotting side. This allows to unify the code used for plotting Brillouin and ODT/brightfield preview images.