### PR TITLE
Speedup the Brillouin acquisition

### DIFF
--- a/BrillouinAcquisition/src/Acquisition/Acquisition.h
+++ b/BrillouinAcquisition/src/Acquisition/Acquisition.h
@@ -29,6 +29,8 @@ public slots:
 	void openFile(StoragePath path, int flag = H5F_ACC_RDWR);
 	void openFile();
 	void newRepetition(ACQUISITION_MODE mode);
+	void startedWritingToFile();
+	void finishedWritingToFile();
 	int closeFile();
 	
 	bool isModeEnabled(ACQUISITION_MODE mode);
@@ -39,6 +41,8 @@ public slots:
 private:
 	StoragePath m_path;
 	ACQUISITION_MODE m_enabledModes = ACQUISITION_MODE::NONE;	// which mode is currently acquiring
+	Thread* m_storageThread;
+	bool m_writingToFile{ false };
 
 private slots:
 	void checkFilename();

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/AcquisitionMode.h
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/AcquisitionMode.h
@@ -32,7 +32,7 @@ public slots:
 
 protected:
 	Acquisition *m_acquisition = nullptr;
-	virtual void abortMode() = 0;
+	virtual void abortMode(std::unique_ptr <StorageWrapper> & storage) = 0;
 	ACQUISITION_STATUS m_status{ ACQUISITION_STATUS::DISABLED };
 
 private slots:

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.cpp
@@ -271,8 +271,6 @@ void Brillouin::acquire(std::unique_ptr <StorageWrapper>& storage) {
 	// close camera libraries, clear buffers
 	m_andor->stopAcquisition();
 
-	QMetaObject::invokeMethod(storage.get(), "s_finishedQueueing", Qt::AutoConnection);
-
 	(*m_scanControl)->setPreset(SCAN_LASEROFF);
 
 	(*m_scanControl)->setPosition(m_startPosition);
@@ -282,6 +280,7 @@ void Brillouin::acquire(std::unique_ptr <StorageWrapper>& storage) {
 	// Here we wait until the storage object indicate it finished to write to the file.
 	QEventLoop loop;
 	connect(storage.get(), SIGNAL(finished()), &loop, SLOT(quit()));
+	QMetaObject::invokeMethod(storage.get(), "s_finishedQueueing", Qt::AutoConnection);
 	loop.exec();
 
 	std::string info = "Acquisition finished.";
@@ -298,11 +297,10 @@ void Brillouin::abortMode(std::unique_ptr <StorageWrapper>& storage) {
 	m_acquisition->disableMode(ACQUISITION_MODE::BRILLOUIN);
 	m_status = ACQUISITION_STATUS::ABORTED;
 
-	QMetaObject::invokeMethod(storage.get(), "s_finishedQueueing", Qt::AutoConnection);
-
 	// Here we wait until the storage object indicate it finished to write to the file.
 	QEventLoop loop;
 	connect(storage.get(), SIGNAL(finished()), &loop, SLOT(quit()));
+	QMetaObject::invokeMethod(storage.get(), "s_finishedQueueing", Qt::AutoConnection);
 	loop.exec();
 
 	emit(s_acquisitionStatus(m_status));

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.h
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.h
@@ -88,7 +88,7 @@ private:
 	int nrCalibrations = 1;
 	void calibrate(std::unique_ptr <StorageWrapper>& storage);
 
-	void abortMode() override;
+	void abortMode(std::unique_ptr <StorageWrapper>& storage) override;
 
 private slots:
 	void acquire(std::unique_ptr <StorageWrapper>& storage) override;

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.h
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.h
@@ -7,6 +7,7 @@
 #include "../../thread.h"
 #include "../../circularBuffer.h"
 
+
 struct SCAN_ORDER {
 	bool automatical{ true };
 	int x{ 0 };	// first scan in x-direction
@@ -79,7 +80,6 @@ public slots:
 private:
 	BRILLOUIN_SETTINGS m_settings;
 	SCAN_ORDER m_scanOrder;
-	//Thread m_storageThread;
 	Andor* m_andor;
 	ScanControl** m_scanControl;
 	bool m_running = false;				// is acquisition currently running

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.cpp
@@ -261,6 +261,11 @@ void Fluorescence::acquire(std::unique_ptr <StorageWrapper>& storage, std::vecto
 		emit(s_repetitionProgress(percentage, remaining));
 	}
 
+	// Here we wait until the storage object indicate it finished to write to the file.
+	QEventLoop loop;
+	connect(storage.get(), SIGNAL(finished()), &loop, SLOT(quit()));
+	loop.exec();
+
 	m_status = ACQUISITION_STATUS::FINISHED;
 	emit(s_acquisitionStatus(m_status));
 }

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.cpp
@@ -200,7 +200,7 @@ void Fluorescence::acquire(std::unique_ptr <StorageWrapper>& storage, std::vecto
 	for (auto const& channel : channels) {
 		// Abort if requested
 		if (m_abort) {
-			this->abortMode();
+			this->abortMode(storage);
 			return;
 		}
 
@@ -270,8 +270,16 @@ void Fluorescence::acquire(std::unique_ptr <StorageWrapper>& storage, std::vecto
 	emit(s_acquisitionStatus(m_status));
 }
 
-void Fluorescence::abortMode() {
+void Fluorescence::abortMode(std::unique_ptr <StorageWrapper> & storage) {
 	m_acquisition->disableMode(ACQUISITION_MODE::FLUORESCENCE);
 	m_status = ACQUISITION_STATUS::ABORTED;
+
+	QMetaObject::invokeMethod(storage.get(), "s_finishedQueueing", Qt::AutoConnection);
+
+	// Here we wait until the storage object indicate it finished to write to the file.
+	QEventLoop loop;
+	connect(storage.get(), SIGNAL(finished()), &loop, SLOT(quit()));
+	loop.exec();
+
 	emit(s_acquisitionStatus(m_status));
 }

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.cpp
@@ -264,6 +264,7 @@ void Fluorescence::acquire(std::unique_ptr <StorageWrapper>& storage, std::vecto
 	// Here we wait until the storage object indicate it finished to write to the file.
 	QEventLoop loop;
 	connect(storage.get(), SIGNAL(finished()), &loop, SLOT(quit()));
+	QMetaObject::invokeMethod(storage.get(), "s_finishedQueueing", Qt::AutoConnection);
 	loop.exec();
 
 	m_status = ACQUISITION_STATUS::FINISHED;
@@ -274,11 +275,10 @@ void Fluorescence::abortMode(std::unique_ptr <StorageWrapper> & storage) {
 	m_acquisition->disableMode(ACQUISITION_MODE::FLUORESCENCE);
 	m_status = ACQUISITION_STATUS::ABORTED;
 
-	QMetaObject::invokeMethod(storage.get(), "s_finishedQueueing", Qt::AutoConnection);
-
 	// Here we wait until the storage object indicate it finished to write to the file.
 	QEventLoop loop;
 	connect(storage.get(), SIGNAL(finished()), &loop, SLOT(quit()));
+	QMetaObject::invokeMethod(storage.get(), "s_finishedQueueing", Qt::AutoConnection);
 	loop.exec();
 
 	emit(s_acquisitionStatus(m_status));

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.cpp
@@ -189,6 +189,8 @@ void Fluorescence::acquire(std::unique_ptr <StorageWrapper>& storage, std::vecto
 		}
 	}
 
+	QMetaObject::invokeMethod(storage.get(), "startWritingQueues", Qt::AutoConnection);
+
 	QElapsedTimer measurementTimer;
 	measurementTimer.start();
 

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.h
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.h
@@ -58,7 +58,7 @@ private:
 	void configureCamera();
 	FLUORESCENCE_MODE previewChannel{ FLUORESCENCE_MODE::NONE };
 
-	void abortMode() override;
+	void abortMode(std::unique_ptr <StorageWrapper> & storage) override;
 
 private slots:
 	void acquire(std::unique_ptr <StorageWrapper>& storage) override;

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.cpp
@@ -133,6 +133,8 @@ void ODT::acquire(std::unique_ptr <StorageWrapper> & storage) {
 	m_status = ACQUISITION_STATUS::STARTED;
 	emit(s_acquisitionStatus(m_status));
 
+	QMetaObject::invokeMethod(storage.get(), "startWritingQueues", Qt::AutoConnection);
+
 	// move to ODT configuration
 	(*m_NIDAQ)->setPreset(SCAN_ODT);
 

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.cpp
@@ -195,6 +195,7 @@ void ODT::acquire(std::unique_ptr <StorageWrapper> & storage) {
 	// Here we wait until the storage object indicate it finished to write to the file.
 	QEventLoop loop;
 	connect(storage.get(), SIGNAL(finished()), &loop, SLOT(quit()));
+	QMetaObject::invokeMethod(storage.get(), "s_finishedQueueing", Qt::AutoConnection);
 	loop.exec();
 
 	m_status = ACQUISITION_STATUS::FINISHED;
@@ -327,11 +328,10 @@ void ODT::calculateVoltages(ODT_MODE mode) {
 }
 
 void ODT::abortMode(std::unique_ptr <StorageWrapper> & storage) {
-	QMetaObject::invokeMethod(storage.get(), "s_finishedQueueing", Qt::AutoConnection);
-
 	// Here we wait until the storage object indicate it finished to write to the file.
 	QEventLoop loop;
 	connect(storage.get(), SIGNAL(finished()), &loop, SLOT(quit()));
+	QMetaObject::invokeMethod(storage.get(), "s_finishedQueueing", Qt::AutoConnection);
 	loop.exec();
 
 	abortMode();

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.cpp
@@ -192,6 +192,11 @@ void ODT::acquire(std::unique_ptr <StorageWrapper> & storage) {
 		QMetaObject::invokeMethod(storage.get(), "s_enqueuePayload", Qt::AutoConnection, Q_ARG(ODTIMAGE*, img));
 	}
 
+	// Here we wait until the storage object indicate it finished to write to the file.
+	QEventLoop loop;
+	connect(storage.get(), SIGNAL(finished()), &loop, SLOT(quit()));
+	loop.exec();
+
 	m_status = ACQUISITION_STATUS::FINISHED;
 	emit(s_acquisitionStatus(m_status));
 }

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.h
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.h
@@ -63,7 +63,8 @@ private:
 
 	void calculateVoltages(ODT_MODE);
 
-	void abortMode() override;
+	void abortMode(std::unique_ptr <StorageWrapper> & storage) override;
+	void abortMode();
 
 private slots:
 	void acquire(std::unique_ptr <StorageWrapper> & storage) override;

--- a/BrillouinAcquisition/src/Devices/ZeissECU.cpp
+++ b/BrillouinAcquisition/src/Devices/ZeissECU.cpp
@@ -149,7 +149,7 @@ void ZeissECU::setPosition(POINT3 position) {
 	m_mcu->setX(position.x);
 	m_mcu->setY(position.y);
 	m_focus->setZ(position.z);
-	calculateCurrentPositionBounds();
+	calculateCurrentPositionBounds(position);
 }
 
 void ZeissECU::setPositionRelativeX(double positionX) {

--- a/BrillouinAcquisition/src/Devices/ZeissECU.cpp
+++ b/BrillouinAcquisition/src/Devices/ZeissECU.cpp
@@ -263,6 +263,10 @@ void Element::send(std::string message) {
 	m_comObject->send(m_prefix + "P" + message);
 }
 
+void Element::clear() {
+	m_comObject->clear();
+}
+
 void Element::setDevice(com *device) {
 	m_comObject = device;
 }
@@ -299,7 +303,8 @@ void Focus::setZ(double position) {
 	int inc = positive_modulo(position, m_rangeFocus);
 
 	std::string pos = helper::dec2hex(inc, 6);
-	std::string answer = receive("ZD" + pos);
+	send("ZD" + pos);
+	clear();
 }
 
 void Focus::setVelocityZ(double velocity) {

--- a/BrillouinAcquisition/src/Devices/ZeissECU.h
+++ b/BrillouinAcquisition/src/Devices/ZeissECU.h
@@ -20,6 +20,7 @@ public:
 	~Element();
 	std::string receive(std::string request);
 	void send(std::string message);
+	void clear();
 	void setDevice(com *device);
 	inline int positive_modulo(int i, int n) {
 		return (i % n + n) % n;

--- a/BrillouinAcquisition/src/Devices/scancontrol.cpp
+++ b/BrillouinAcquisition/src/Devices/scancontrol.cpp
@@ -83,6 +83,10 @@ void ScanControl::calculateHomePositionBounds() {
 
 void ScanControl::calculateCurrentPositionBounds() {
 	POINT3 currentPosition = getPosition();
+	calculateCurrentPositionBounds(currentPosition);
+}
+
+void ScanControl::calculateCurrentPositionBounds(POINT3 currentPosition) {
 	m_currentPositionBounds.xMin = m_absoluteBounds.xMin - currentPosition.x;
 	m_currentPositionBounds.xMax = m_absoluteBounds.xMax - currentPosition.x;
 	m_currentPositionBounds.yMin = m_absoluteBounds.yMin - currentPosition.y;

--- a/BrillouinAcquisition/src/Devices/scancontrol.h
+++ b/BrillouinAcquisition/src/Devices/scancontrol.h
@@ -133,6 +133,8 @@ protected:
 
 	void calculateHomePositionBounds();
 	void calculateCurrentPositionBounds();
+	void calculateCurrentPositionBounds(POINT3 currentPosition);
+
 
 	BOUNDS m_absoluteBounds;
 	BOUNDS m_homePositionBounds;

--- a/BrillouinAcquisition/src/storageWrapper.cpp
+++ b/BrillouinAcquisition/src/storageWrapper.cpp
@@ -26,6 +26,7 @@ StorageWrapper::~StorageWrapper() {
 	}
 	queueTimer->stop();
 	delete queueTimer;
+	emit(finished());
 }
 
 void StorageWrapper::init() {
@@ -62,13 +63,16 @@ void StorageWrapper::startWritingQueues() {
 
 void StorageWrapper::stopWritingQueues() {
 	m_observeQueues = false;
+	m_finished = true;
 	queueTimer->stop();
+	m_finishedQueueing = true;
+	emit(finished());
 }
 
 void StorageWrapper::s_writeQueues() {
 	while (!m_payloadQueueBrillouin.isEmpty()) {
 		if (m_abort) {
-			m_finished = true;
+			stopWritingQueues();
 			return;
 		}
 		IMAGE *img = m_payloadQueueBrillouin.dequeue();
@@ -82,7 +86,7 @@ void StorageWrapper::s_writeQueues() {
 
 	while (!m_payloadQueueODT.isEmpty()) {
 		if (m_abort) {
-			m_finished = true;
+			stopWritingQueues();
 			return;
 		}
 		ODTIMAGE *img = m_payloadQueueODT.dequeue();
@@ -96,7 +100,7 @@ void StorageWrapper::s_writeQueues() {
 
 	while (!m_payloadQueueFluorescence.isEmpty()) {
 		if (m_abort) {
-			m_finished = true;
+			stopWritingQueues();
 			return;
 		}
 		FLUOIMAGE *img = m_payloadQueueFluorescence.dequeue();
@@ -110,7 +114,7 @@ void StorageWrapper::s_writeQueues() {
 
 	while (!m_calibrationQueue.isEmpty()) {
 		if (m_abort) {
-			m_finished = true;
+			stopWritingQueues();
 			return;
 		}
 		CALIBRATION *cal = m_calibrationQueue.dequeue();

--- a/BrillouinAcquisition/src/storageWrapper.h
+++ b/BrillouinAcquisition/src/storageWrapper.h
@@ -23,6 +23,8 @@ private:
 	bool m_observeQueues = false;
 	bool m_finishedQueueing = false;
 
+	QTimer *queueTimer = nullptr;
+
 public:
 	StorageWrapper(
 		QObject *parent = nullptr,
@@ -37,13 +39,15 @@ public:
 	QQueue<CALIBRATION*> m_calibrationQueue;
 	bool m_abort = false;
 
-	void startWritingQueues();
-	void stopWritingQueues();
-
 	int m_writtenImagesNr{ 0 };
 	int m_writtenCalibrationsNr{ 0 };
 
 public slots:
+	void init();
+
+	void startWritingQueues();
+	void stopWritingQueues();
+
 	void s_writeQueues();
 
 	void s_enqueuePayload(IMAGE*);
@@ -55,6 +59,7 @@ public slots:
 
 signals:
 	void finished();
+	void started();
 };
 
 #endif //STORAGEWRAPPER_H


### PR DESCRIPTION
This PR aims to speedup the Brillouin acquisition.

Current acquisition duration:

Acquired positions and images | Nominal duration [s] | Duration with f832da60109f05b57d9699f1a5b0b6bd37712381 [s] | Duration after b78c5f3f12ca88b7b918a8a1d850325648411b20 [s] | Duration after edc48a3bc46d355aa435faa76593db70eec5183e [s]
-|-|-|-|-
0.5 s x 2 x 50 | 50 | 69 | 57 | 53
0.2 s x 2 x 50 | 20 | 38 | 27 | 23
0.1 s x 2 x 50 | 10 | 29 | 17 | 13
total overhead | - |  ~19 | ~7 | ~3
overhead per position | - |  0.4 | 0.14 | 0.06
0.5 s x 1 x 50 | 25 | 44 | 31 | 28
0.2 s x 1 x 50 | 10 | 29 | 17 | 13
0.1 s x 1 x 50 | 5 | 24 | 12 | 8
overhead | - | ~19 | ~7 | ~3
overhead per position | - |  0.4 | 0.14 | 0.06