### PR TITLE
Store camera meta data

### DIFF
--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.h
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.h
@@ -85,6 +85,8 @@ private:
 
 	void calibrate(std::unique_ptr <StorageWrapper>& storage);
 
+	std::string getBinningString();
+
 	BRILLOUIN_SETTINGS m_settings;
 	SCAN_ORDER m_scanOrder;
 	Camera** m_andor;

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.cpp
@@ -228,6 +228,18 @@ void Fluorescence::configureCamera() {
 	m_settings.camera.frameCount = 1;
 }
 
+std::string Fluorescence::getBinningString() {
+	std::string binning{ "1x1" };
+	if (m_settings.camera.roi.binning == L"8x8") {
+		binning = "1x1";
+	} else if (m_settings.camera.roi.binning == L"4x4") {
+		binning = "1x1";
+	} else if (m_settings.camera.roi.binning == L"2x2") {
+		binning = "1x1";
+	}
+	return binning;
+}
+
 /*
  * Private slots
  */
@@ -326,7 +338,9 @@ void Fluorescence::acquire(std::unique_ptr <StorageWrapper>& storage, std::vecto
 		// the datetime has to be set here, otherwise it would be determined by the time the queue is processed
 		std::string date = QDateTime::currentDateTime().toOffsetFromUtc(QDateTime::currentDateTime().offsetFromUtc())
 			.toString(Qt::ISODateWithMs).toStdString();
-		FLUOIMAGE* img = new FLUOIMAGE(imageNumber, rank_data, dims_data, date, channel->name, *images_);
+		std::string binning = getBinningString();
+		FLUOIMAGE* img = new FLUOIMAGE(imageNumber, rank_data, dims_data, date, channel->name, *images_,
+			m_settings.camera.exposureTime, m_settings.camera.gain, binning);
 
 		QMetaObject::invokeMethod(
 			storage.get(),

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.h
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.h
@@ -62,6 +62,8 @@ private:
 	FLUORESCENCE_MODE m_currentPreviewChannel{ FLUORESCENCE_MODE::NONE };
 	FLUORESCENCE_MODE m_previousPreviewChannel{ FLUORESCENCE_MODE::NONE };
 
+	std::string getBinningString();
+
 
 private slots:
 	void acquire(std::unique_ptr <StorageWrapper>& storage) override;

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.cpp
@@ -293,6 +293,18 @@ void ODT::calculateVoltages(ODT_MODE mode) {
 	}
 }
 
+std::string ODT::getBinningString() {
+	std::string binning{ "1x1" };
+	if (m_cameraSettings.roi.binning == L"8x8") {
+		binning = "1x1";
+	} else if (m_cameraSettings.roi.binning == L"4x4") {
+		binning = "1x1";
+	} else if (m_cameraSettings.roi.binning == L"2x2") {
+		binning = "1x1";
+	}
+	return binning;
+}
+
 /*
  * Private slots
  */
@@ -336,6 +348,7 @@ void ODT::acquire(std::unique_ptr <StorageWrapper> & storage) {
 	int rank_data{ 3 };
 	hsize_t dims_data[3] = { 1, (hsize_t)m_cameraSettings.roi.height, (hsize_t)m_cameraSettings.roi.width };
 	int bytesPerFrame = m_cameraSettings.roi.width * m_cameraSettings.roi.height;
+	std::string binning = getBinningString();
 	if (bytesPerFrame) {
 		for (gsl::index i{ 0 }; i < m_acqSettings.numberPoints; i++) {
 
@@ -358,7 +371,8 @@ void ODT::acquire(std::unique_ptr <StorageWrapper> & storage) {
 			// the datetime has to be set here, otherwise it would be determined by the time the queue is processed
 			std::string date = QDateTime::currentDateTime().toOffsetFromUtc(QDateTime::currentDateTime().offsetFromUtc())
 				.toString(Qt::ISODateWithMs).toStdString();
-			ODTIMAGE* img = new ODTIMAGE((int)i, rank_data, dims_data, date, *images_);
+			ODTIMAGE* img = new ODTIMAGE((int)i, rank_data, dims_data, date, *images_,
+				m_cameraSettings.exposureTime, m_cameraSettings.gain, binning);
 
 			QMetaObject::invokeMethod(
 				storage.get(),

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.h
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.h
@@ -70,6 +70,8 @@ private:
 
 	QTimer* m_algnTimer{ nullptr };
 
+	std::string getBinningString();
+
 private slots:
 	void acquire(std::unique_ptr <StorageWrapper> & storage) override;
 	

--- a/BrillouinAcquisition/src/storageWrapper.cpp
+++ b/BrillouinAcquisition/src/storageWrapper.cpp
@@ -123,7 +123,7 @@ void StorageWrapper::s_writeQueues() {
 			return;
 		}
 		CALIBRATION *cal = m_calibrationQueue.dequeue();
-		setCalibrationData(cal->index, cal->data, cal->rank, cal->dims, cal->sample, cal->shift, cal->date);
+		setCalibrationData(cal->index, cal->data, cal->rank, cal->dims, cal->sample, cal->shift, cal->date, cal->exposure, cal->gain, cal->binning);
 		//std::string info = "Calibration written " + std::to_string(m_writtenCalibrationsNr);
 		//qInfo(logInfo()) << info.c_str();
 		m_writtenCalibrationsNr++;


### PR DESCRIPTION
Closes #107.

Requires https://github.com/BrillouinMicroscopy/h5bm/pull/6.

Todo:
- [x] Store meta data also for ODT and Fluorescence images