### PR TITLE
Implement saving the scale calibration for each acquisition

### DIFF
--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/AcquisitionMode.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/AcquisitionMode.cpp
@@ -5,8 +5,8 @@
  * Public definitions
  */
 
-AcquisitionMode::AcquisitionMode(QObject *parent, Acquisition *acquisition)
-	: QObject(parent), m_acquisition(acquisition) {
+AcquisitionMode::AcquisitionMode(QObject *parent, Acquisition *acquisition, ScanControl **scanControl)
+	: QObject(parent), m_acquisition(acquisition), m_scanControl(scanControl) {
 }
 
 AcquisitionMode::~AcquisitionMode() {
@@ -27,4 +27,13 @@ ACQUISITION_STATUS AcquisitionMode::getStatus() {
 void AcquisitionMode::setAcquisitionStatus(ACQUISITION_STATUS status) {
 	m_status = status;
 	emit(s_acquisitionStatus(m_status));
+}
+
+void AcquisitionMode::writeScaleCalibration(std::unique_ptr <StorageWrapper>& storage) {
+	auto scaleCalibration = (*m_scanControl)->getScaleCalibration();
+
+	auto positionStage = (*m_scanControl)->getPosition(PositionType::STAGE);
+	auto positionScanner = (*m_scanControl)->getPosition(PositionType::SCANNER);
+
+	storage->setScaleCalibration({ scaleCalibration, positionStage, positionScanner });
 }

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/AcquisitionMode.h
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/AcquisitionMode.h
@@ -4,7 +4,8 @@
 #include <QtCore>
 #include <gsl/gsl>
 
-#include "../Acquisition.h"
+#include "..\Acquisition.h"
+#include "..\..\Devices\ScanControls\ScanControl.h"
 
 enum class ACQUISITION_STATUS {
 	DISABLED,
@@ -22,7 +23,7 @@ class AcquisitionMode : public QObject {
 	Q_OBJECT
 
 public:
-	AcquisitionMode(QObject *parent, Acquisition *acquisition);
+	AcquisitionMode(QObject *parent, Acquisition *acquisition, ScanControl** scanControl);
 	~AcquisitionMode();
 
 	bool m_abort{ false };
@@ -39,8 +40,11 @@ protected:
 
 	void setAcquisitionStatus(ACQUISITION_STATUS);
 
+	void writeScaleCalibration(std::unique_ptr <StorageWrapper>& storage);
+
 	ACQUISITION_STATUS m_status{ ACQUISITION_STATUS::DISABLED };
 	Acquisition* m_acquisition{ nullptr };
+	ScanControl** m_scanControl{ nullptr };
 
 private slots:
 	virtual void acquire(std::unique_ptr <StorageWrapper> & storage) = 0;

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.cpp
@@ -11,7 +11,7 @@ using namespace std::filesystem;
  */
 
 Brillouin::Brillouin(QObject* parent, Acquisition* acquisition, Camera** andor, ScanControl** scanControl)
-	: AcquisitionMode(parent, acquisition), m_andor(andor), m_scanControl(scanControl) {
+	: AcquisitionMode(parent, acquisition, scanControl), m_andor(andor) {
 	static QMetaObject::Connection connection = QWidget::connect(
 		this,
 		&Brillouin::s_scanOrderChanged,
@@ -443,6 +443,8 @@ void Brillouin::acquire(std::unique_ptr <StorageWrapper>& storage) {
 	storage->setResolution("z", m_settings.zSteps);
 
 	auto resolutionXout = storage->getResolution("x");
+
+	writeScaleCalibration(storage);
 
 	/*
 	 * Update the positions vector

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.h
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.h
@@ -3,7 +3,6 @@
 
 #include "AcquisitionMode.h"
 #include "..\..\Devices\Cameras\Camera.h"
-#include "..\..\Devices\ScanControls\ScanControl.h"
 #include "..\..\thread.h"
 #include "..\..\circularBuffer.h"
 
@@ -92,8 +91,7 @@ private:
 
 	BRILLOUIN_SETTINGS m_settings;
 	SCAN_ORDER m_scanOrder;
-	Camera** m_andor;
-	ScanControl** m_scanControl;
+	Camera** m_andor{ nullptr };
 	bool m_running{ false };				// is acquisition currently running
 	POINT3 m_startPosition{ 0, 0, 0 };
 

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.cpp
@@ -6,7 +6,7 @@
  */
 
 Fluorescence::Fluorescence(QObject* parent, Acquisition* acquisition, Camera** camera, ScanControl** scanControl)
-	: AcquisitionMode(parent, acquisition), m_camera(camera), m_scanControl(scanControl) {}
+	: AcquisitionMode(parent, acquisition, scanControl), m_camera(camera) {}
 
 Fluorescence::~Fluorescence() {
 }
@@ -261,6 +261,8 @@ void Fluorescence::acquire(std::unique_ptr <StorageWrapper>& storage, std::vecto
 			return;
 		}
 	}
+
+	writeScaleCalibration(storage);
 
 	QMetaObject::invokeMethod(
 		storage.get(),

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.h
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.h
@@ -55,8 +55,7 @@ private:
 	std::vector<ChannelSettings*> getEnabledChannels();
 	void configureCamera();
 
-	Camera** m_camera;
-	ScanControl** m_scanControl;
+	Camera** m_camera{ nullptr };
 
 	FLUORESCENCE_SETTINGS m_settings;
 	FLUORESCENCE_MODE m_currentPreviewChannel{ FLUORESCENCE_MODE::NONE };

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.cpp
@@ -7,7 +7,7 @@
  */
 
 ODT::ODT(QObject* parent, Acquisition* acquisition, Camera** camera, ODTControl** ODTControl)
-	: AcquisitionMode(parent, acquisition), m_camera(camera), m_ODTControl(ODTControl) {
+	: AcquisitionMode(parent, acquisition, (ScanControl**)ODTControl), m_camera(camera), m_ODTControl(ODTControl) {
 }
 
 ODT::~ODT() {
@@ -324,6 +324,8 @@ void ODT::acquire(std::unique_ptr <StorageWrapper> & storage) {
 	// Set first mirror voltage already
 	(*m_ODTControl)->setVoltage(m_acqSettings.voltages[0]);
 	Sleep(100);
+
+	writeScaleCalibration(storage);
 
 	ACQ_VOLTAGES voltages;
 

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.h
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.h
@@ -62,8 +62,8 @@ private:
 	};
 	ODT_SETTINGS m_algnSettings;
 	CAMERA_SETTINGS m_cameraSettings{ 0.002, 0 };
-	Camera **m_camera;
-	ODTControl **m_ODTControl;
+	Camera** m_camera{ nullptr };
+	ODTControl** m_ODTControl{ nullptr };
 	bool m_algnRunning{ false };			// is alignment currently running
 
 	int m_algnPositionIndex{ 0 };

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ScaleCalibration.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ScaleCalibration.cpp
@@ -7,7 +7,7 @@
  */
 
 ScaleCalibration::ScaleCalibration(QObject* parent, Acquisition* acquisition, Camera** camera, ScanControl** scanControl)
-	: AcquisitionMode(parent, acquisition), m_camera(camera), m_scanControl(scanControl) {
+	: AcquisitionMode(parent, acquisition, scanControl), m_camera(camera) {
 }
 
 ScaleCalibration::~ScaleCalibration() {}

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ScaleCalibration.h
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ScaleCalibration.h
@@ -28,8 +28,7 @@ private:
 
 	void save();
 
-	Camera** m_camera;
-	ScanControl** m_scanControl;
+	Camera** m_camera{ nullptr };
 
 	ScaleCalibrationData m_scaleCalibration;
 

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/VoltageCalibration.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/VoltageCalibration.cpp
@@ -8,7 +8,7 @@
  */
 
 VoltageCalibration::VoltageCalibration(QObject* parent, Acquisition* acquisition, Camera** camera, ODTControl** ODTControl)
-	: AcquisitionMode(parent, acquisition), m_camera(camera), m_ODTControl(ODTControl) {
+	: AcquisitionMode(parent, acquisition, (ScanControl**)ODTControl), m_camera(camera), m_ODTControl(ODTControl) {
 }
 
 VoltageCalibration::~VoltageCalibration() {}

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/VoltageCalibration.h
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/VoltageCalibration.h
@@ -46,8 +46,8 @@ private:
 
 	CALIBRATION_SETTINGS m_acqSettings{};
 	CAMERA_SETTINGS m_cameraSettings{ 0.002, 0 };
-	Camera** m_camera;
-	ODTControl** m_ODTControl;
+	Camera** m_camera{ nullptr };
+	ODTControl** m_ODTControl{ nullptr };
 
 	double m_minimalIntensity{ 100 };		// [1] minimum peak intensity for valid peaks
 

--- a/BrillouinAcquisition/src/Devices/ScanControls/ScanControl.cpp
+++ b/BrillouinAcquisition/src/Devices/ScanControls/ScanControl.cpp
@@ -20,9 +20,23 @@ void ScanControl::movePosition(POINT3 distance) {
 	setPosition(position);
 }
 
-POINT3 ScanControl::getPosition() {
-	// We return the absolute position, including the position of the stage and the scanner
-	auto pos = m_positionStage + m_positionScanner;
+POINT3 ScanControl::getPosition(PositionType positionType) {
+	auto pos = POINT2{};
+	switch (positionType) {
+		case PositionType::BOTH:
+			// We return the absolute position, including the position of the stage and the scanner
+			pos = m_positionStage + m_positionScanner;
+			break;
+		case PositionType::STAGE:
+			pos = m_positionStage;
+			break;
+		case PositionType::SCANNER:
+			pos = m_positionScanner;
+			break;
+		default:
+			break;
+	}
+
 	return POINT3{ pos.x, pos.y, m_positionFocus };
 }
 

--- a/BrillouinAcquisition/src/Devices/ScanControls/ScanControl.cpp
+++ b/BrillouinAcquisition/src/Devices/ScanControls/ScanControl.cpp
@@ -257,6 +257,10 @@ void ScanControl::setScaleCalibration(ScaleCalibrationData scaleCalibration) {
 	emit(s_scaleCalibrationChanged(convertPositionsToPix()));
 }
 
+ScaleCalibrationData ScanControl::getScaleCalibration() {
+	return m_scaleCalibration;
+}
+
 std::vector<POINT2> ScanControl::getPositionsPix(std::vector<POINT3> positionsMicrometer) {
 	// Cache the requested positions so we can re-emit updated positions
 	// in case the scale calibration changes

--- a/BrillouinAcquisition/src/Devices/ScanControls/ScanControl.h
+++ b/BrillouinAcquisition/src/Devices/ScanControls/ScanControl.h
@@ -186,6 +186,7 @@ public slots:
 	void announceSavedPositionsNormalized();
 	
 	void setScaleCalibration(ScaleCalibrationData scaleCalibration);
+	ScaleCalibrationData getScaleCalibration();
 
 	std::vector<POINT2> getPositionsPix(std::vector<POINT3> positionsMicrometer);
 

--- a/BrillouinAcquisition/src/Devices/ScanControls/ScanControl.h
+++ b/BrillouinAcquisition/src/Devices/ScanControls/ScanControl.h
@@ -39,6 +39,12 @@ enum class Capabilities {
 	COUNT
 };
 
+enum class PositionType {
+	BOTH,
+	STAGE,
+	SCANNER
+};
+
 typedef enum class enDeviceInput {
 	PUSHBUTTON,
 	INTBOX,
@@ -120,7 +126,7 @@ public:
 	// moves the position relative to current position
 	void movePosition(POINT2 distance);
 	void movePosition(POINT3 distance);
-	virtual POINT3 getPosition();
+	virtual POINT3 getPosition(PositionType positionType = PositionType::BOTH);
 
 	typedef enum class enScanDevice {
 		ZEISSECU = 0,

--- a/BrillouinAcquisition/src/Devices/ScanControls/ZeissECU.cpp
+++ b/BrillouinAcquisition/src/Devices/ScanControls/ZeissECU.cpp
@@ -81,7 +81,7 @@ void ZeissECU::setPosition(POINT3 position) {
 	setPosition(POINT2{ position.x, position.y });
 }
 
-POINT3 ZeissECU::getPosition() {
+POINT3 ZeissECU::getPosition(PositionType positionType) {
 	// Update the positions from the hardware
 	m_positionStage.x = m_mcu->getX();
 	m_positionStage.y = m_mcu->getY();
@@ -89,7 +89,7 @@ POINT3 ZeissECU::getPosition() {
 	m_positionFocus = m_focus->getZ();
 
 	// Return the current position
-	return ScanControl::getPosition();
+	return ScanControl::getPosition(positionType);
 }
 
 void ZeissECU::setDevice(com* device) {

--- a/BrillouinAcquisition/src/Devices/ScanControls/ZeissECU.h
+++ b/BrillouinAcquisition/src/Devices/ScanControls/ZeissECU.h
@@ -116,7 +116,7 @@ public:
 
 	void setPosition(POINT3 position) override;
 	void setPosition(POINT2 position) override;
-	POINT3 getPosition() override;
+	POINT3 getPosition(PositionType positionType = PositionType::BOTH) override;
 
 	void setDevice(com *device);
 

--- a/BrillouinAcquisition/src/Devices/ScanControls/ZeissMTB.cpp
+++ b/BrillouinAcquisition/src/Devices/ScanControls/ZeissMTB.cpp
@@ -88,7 +88,7 @@ void ZeissMTB::setPosition(POINT3 position) {
 	setPosition(POINT2{ position.x, position.y });
 }
 
-POINT3 ZeissMTB::getPosition() {
+POINT3 ZeissMTB::getPosition(PositionType positionType) {
 	// Update the positions from the hardware
 	if (m_stageX && m_stageY) {
 		m_positionStage.x = m_stageX->GetPosition("µm");
@@ -99,7 +99,7 @@ POINT3 ZeissMTB::getPosition() {
 	}
 
 	// Return the current position
-	return ScanControl::getPosition();
+	return ScanControl::getPosition(positionType);
 }
 
 /*

--- a/BrillouinAcquisition/src/Devices/ScanControls/ZeissMTB.h
+++ b/BrillouinAcquisition/src/Devices/ScanControls/ZeissMTB.h
@@ -20,7 +20,7 @@ public:
 
 	void setPosition(POINT2 position) override;
 	void setPosition(POINT3 position) override;
-	POINT3 getPosition() override;
+	POINT3 getPosition(PositionType positionType = PositionType::BOTH) override;
 
 public slots:
 	void init() override;

--- a/BrillouinAcquisition/src/Devices/ScanControls/ZeissMTB_Erlangen.cpp
+++ b/BrillouinAcquisition/src/Devices/ScanControls/ZeissMTB_Erlangen.cpp
@@ -89,7 +89,7 @@ void ZeissMTB_Erlangen::setPosition(POINT3 position) {
 	setPosition(POINT2{ position.x, position.y });
 }
 
-POINT3 ZeissMTB_Erlangen::getPosition() {
+POINT3 ZeissMTB_Erlangen::getPosition(PositionType positionType) {
 	if (m_stageX && m_stageY) {
 		m_positionStage.x = m_stageX->GetPosition("µm");
 		m_positionStage.y = m_stageY->GetPosition("µm");
@@ -99,7 +99,7 @@ POINT3 ZeissMTB_Erlangen::getPosition() {
 	}
 
 	// Return the current position
-	return ScanControl::getPosition();
+	return ScanControl::getPosition(positionType);
 }
 
 /*

--- a/BrillouinAcquisition/src/Devices/ScanControls/ZeissMTB_Erlangen.h
+++ b/BrillouinAcquisition/src/Devices/ScanControls/ZeissMTB_Erlangen.h
@@ -18,7 +18,7 @@ public:
 
 	void setPosition(POINT2 position) override;
 	void setPosition(POINT3 position) override;
-	POINT3 getPosition() override;
+	POINT3 getPosition(PositionType positionType = PositionType::BOTH) override;
 
 public slots:
 	void init() override;


### PR DESCRIPTION
This implements saving the scale calibration for each acquisition and will allow to align fluorescence, ODT and Brillouin data, related to #124. Each acquisition needs to store the position of the stage at the beginning of the acquisition and the current scale calibration values.
Saving the scale calibration for each acquisition will allow to switch objectives (i.e. the scale calibration) between acquisitions.

TODO:
- [x] Allow to query the position of the stage and scanner separately
- [x] Write the scale calibration and position of the scanner to the acquisition raw data file

Acquiring a new scale calibration will be implemented in a follow-up PR.