### PR TITLE
Add mock camera class

### DIFF
--- a/BrillouinAcquisition/BrillouinAcquisition.vcxproj
+++ b/BrillouinAcquisition/BrillouinAcquisition.vcxproj
@@ -234,6 +234,9 @@ copy "$(ProgramW6432)\OpenCV\build\x64\vc15\bin\opencv_world451.dll" "$(TargetDi
     <ClCompile Include="GeneratedFiles\Debug\moc_PointGrey.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="GeneratedFiles\Debug\moc_MockCamera.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="GeneratedFiles\Debug\moc_qcustomplot.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
@@ -319,6 +322,9 @@ copy "$(ProgramW6432)\OpenCV\build\x64\vc15\bin\opencv_world451.dll" "$(TargetDi
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="src\Devices\Cameras\Camera.cpp" />
+    <ClCompile Include="src\Devices\Cameras\MockCamera.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="src\Devices\com.cpp" />
     <ClCompile Include="src\Devices\Device.cpp" />
     <ClCompile Include="src\Devices\filtermount.cpp" />
@@ -389,6 +395,12 @@ copy "$(ProgramW6432)\OpenCV\build\x64\vc15\bin\opencv_world451.dll" "$(TargetDi
     <ClInclude Include="GeneratedFiles\ui_ScaleCalibrationDialog.h" />
     <ClInclude Include="src\Acquisition\AcquisitionModes\ScaleCalibrationHelper.h" />
     <ClInclude Include="src\colormaps.h" />
+    <CustomBuild Include="src\Devices\Cameras\MockCamera.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\GeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\GeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp" "-fstdafx.h" "-f../../src/Devices/Cameras/%(Filename)%(Extension)"  -DUNICODE -DWIN32 -DWIN64 -DH5_BUILT_AS_DYNAMIC_LIB -DQT_CORE_LIB -DQT_SERIALPORT_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_PRINTSUPPORT_LIB -D%(PreprocessorDefinitions) "-IC:\Program Files\Thorlabs\Kinesis" "-IC:\Program Files (x86)\National Instruments\Shared\ExternalCompilerSupport\C\include" "-Ic:\Program Files\IDS\uEye\Develop\include" "-IC:\Program Files\Point Grey Research\FlyCapture2\include" "-I.\external\gsl\include" "-IC:\Program Files\HDF_Group\HDF5\1.12.0\include" "-I.\GeneratedFiles" "-I." "-I$(QTDIR)\include" "-I.\GeneratedFiles\$(ConfigurationName)" "-Ic:\Program Files\Andor SDK3" "-I$(QTDIR)\include\QtCore" "-I$(QTDIR)\include\QtSerialPort" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtPrintSupport" "-I.\external\unwrap2" "-I$(INHERIT)" "-Ic:\Program Files\Photometrics\PVCamSDK\Inc" "-IC:\Program Files\Carl Zeiss\MTB 2011 - 2.15.0.2\MTBApi" "-IC:\Program Files\OpenCV\build\include"</Command>
+    </CustomBuild>
     <ClInclude Include="src\POINTS.h" />
     <ClInclude Include="src\unwrap2Wrapper.h" />
     <ClInclude Include="src\xsample.h" />

--- a/BrillouinAcquisition/BrillouinAcquisition.vcxproj.filters
+++ b/BrillouinAcquisition/BrillouinAcquisition.vcxproj.filters
@@ -150,6 +150,9 @@
     <ClCompile Include="GeneratedFiles\Release\moc_PointGrey.cpp">
       <Filter>Generated Files</Filter>
     </ClCompile>
+    <ClCompile Include="GeneratedFiles\Debug\moc_MockCamera.cpp">
+      <Filter>Generated Files</Filter>
+    </ClCompile>
     <ClCompile Include="GeneratedFiles\Debug\moc_Brillouin.cpp">
       <Filter>Generated Files</Filter>
     </ClCompile>
@@ -324,6 +327,9 @@
     <ClCompile Include="GeneratedFiles\Release\moc_ScaleCalibration.cpp">
       <Filter>Generated Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Devices\Cameras\MockCamera.cpp">
+      <Filter>Source Files\Devices\Cameras</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GeneratedFiles\ui_BrillouinAcquisition.h">
@@ -471,6 +477,9 @@
     </CustomBuild>
     <CustomBuild Include="src\ScaleCalibrationDialog.ui">
       <Filter>Form Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="src\Devices\Cameras\MockCamera.h">
+      <Filter>Header Files\Devices\Cameras</Filter>
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>

--- a/BrillouinAcquisition/src/BrillouinAcquisition.cpp
+++ b/BrillouinAcquisition/src/BrillouinAcquisition.cpp
@@ -3008,6 +3008,11 @@ void BrillouinAcquisition::initCameraBrillouin() {
 		case CAMERA_BRILLOUIN_DEVICE::PVCAM:
 			m_andor = new PVCamera();
 			break;
+#ifdef _DEBUG
+		case CAMERA_BRILLOUIN_DEVICE::MOCK:
+			m_andor = new MockCamera();
+			break;
+#endif
 		default:
 			m_andor = new Andor();
 			break;
@@ -3123,6 +3128,15 @@ void BrillouinAcquisition::initCamera() {
 			ui->settingsWidget->setTabIcon(3, m_icons.disconnected);
 			m_hasFluorescence = true;
 			break;
+#ifdef _DEBUG
+		case CAMERA_DEVICE::MOCK:
+			m_brightfieldCamera = new MockCamera();
+			ui->actionConnect_Brightfield_camera->setVisible(true);
+			ui->settingsWidget->addTab(ui->ODTcameraTab, "ODT Camera");
+			ui->settingsWidget->setTabIcon(3, m_icons.disconnected);
+			m_hasFluorescence = true;
+			break;
+#endif
 		default:
 			m_brightfieldCamera = nullptr;
 			ui->actionConnect_Brightfield_camera->setVisible(false);
@@ -3788,7 +3802,7 @@ void BrillouinAcquisition::writeSettings() {
 	QSettings settings(QSettings::IniFormat, QSettings::UserScope,
 		"Guck Lab", "Brillouin Acquisition");
 
-	QString brillouinCamera;
+	auto brillouinCamera = QString{};
 	switch (m_cameraBrillouinType) {
 		case CAMERA_BRILLOUIN_DEVICE::ANDOR:
 			brillouinCamera = "andor";
@@ -3796,12 +3810,17 @@ void BrillouinAcquisition::writeSettings() {
 		case CAMERA_BRILLOUIN_DEVICE::PVCAM:
 			brillouinCamera = "pvcam";
 			break;
+#ifdef _DEBUG
+		case CAMERA_BRILLOUIN_DEVICE::MOCK:
+			brillouinCamera = "mock";
+			break;
+#endif
 		default:
 			brillouinCamera = "andor";
 			break;
 	}
 
-	QString brightfieldCamera;
+	auto brightfieldCamera = QString{};
 	switch (m_cameraType) {
 		case CAMERA_DEVICE::UEYE:
 			brightfieldCamera = "ueye";
@@ -3809,12 +3828,17 @@ void BrillouinAcquisition::writeSettings() {
 		case CAMERA_DEVICE::POINTGREY:
 			brightfieldCamera = "pointgrey";
 			break;
+#ifdef _DEBUG
+		case CAMERA_DEVICE::MOCK:
+			brightfieldCamera = "mock";
+			break;
+#endif
 		default:
 			brightfieldCamera = "none";
 			break;
 	}
 
-	QString stage;
+	auto stage = QString{};
 	switch (m_scanControllerType) {
 		case ScanControl::SCAN_DEVICE::ZEISSECU:
 			stage = "zeiss-ecu";
@@ -3854,7 +3878,13 @@ void BrillouinAcquisition::readSettings() {
 		m_cameraBrillouinType = CAMERA_BRILLOUIN_DEVICE::ANDOR;
 	} else if (BrillouinCam == "pvcam") {
 		m_cameraBrillouinType = CAMERA_BRILLOUIN_DEVICE::PVCAM;
-	} else {
+	}
+#ifdef _DEBUG
+	else if (BrillouinCam == "mock") {
+		m_cameraBrillouinType = CAMERA_BRILLOUIN_DEVICE::MOCK;
+	}
+#endif
+	else {
 		m_cameraBrillouinType = CAMERA_BRILLOUIN_DEVICE::ANDOR;
 	}
 
@@ -3863,7 +3893,13 @@ void BrillouinAcquisition::readSettings() {
 		m_cameraType = CAMERA_DEVICE::UEYE;
 	} else if (BrightfieldCam == "pointgrey") {
 		m_cameraType = CAMERA_DEVICE::POINTGREY;
-	} else {
+	}
+#ifdef _DEBUG
+	else if (BrightfieldCam == "mock") {
+		m_cameraType = CAMERA_DEVICE::MOCK;
+	}
+#endif
+	else {
 		m_cameraType = CAMERA_DEVICE::NONE;
 	}
 

--- a/BrillouinAcquisition/src/BrillouinAcquisition.h
+++ b/BrillouinAcquisition/src/BrillouinAcquisition.h
@@ -9,6 +9,9 @@
 #include "Devices/Cameras/pvcamera.h"
 #include "Devices/Cameras/PointGrey.h"
 #include "Devices/Cameras/uEyeCam.h"
+#ifdef _DEBUG
+	#include "Devices/Cameras/MockCamera.h"
+#endif
 
 #include "Devices/ScanControls/ScanControl.h"
 #include "Devices/ScanControls/ZeissECU.h"
@@ -130,14 +133,33 @@ private:
 		NONE = 0,
 		POINTGREY = 1,
 		UEYE = 2
+#ifdef _DEBUG
+		, MOCK = 3
+#endif
 	} CAMERA_DEVICE;
-	std::vector<std::string> CAMERA_DEVICE_NAMES = { "None", "PointGrey", "uEye" };
+	std::vector<std::string> CAMERA_DEVICE_NAMES = {
+		"None",
+		"PointGrey",
+		"uEye"
+#ifdef _DEBUG
+		, "Mock Camera"
+#endif
+	};
 
 	typedef enum class enCameraBrillouinDevice {
 		ANDOR = 0,
 		PVCAM = 1
+#ifdef _DEBUG
+		, MOCK = 2
+#endif
 	} CAMERA_BRILLOUIN_DEVICE;
-	std::vector<std::string> CAMERA_BRILLOUIN_DEVICE_NAMES = { "Andor", "PVCam" };
+	std::vector<std::string> CAMERA_BRILLOUIN_DEVICE_NAMES = {
+		"Andor",
+		"PVCam"
+#ifdef _DEBUG
+		, "Mock Camera"
+#endif
+	};
 
 	QCPGraph* m_positionScannerMarker{ nullptr };
 	POINT2 m_positionScanner{ -1, -1 };

--- a/BrillouinAcquisition/src/Devices/Cameras/MockCamera.cpp
+++ b/BrillouinAcquisition/src/Devices/Cameras/MockCamera.cpp
@@ -20,6 +20,9 @@ void MockCamera::connectDevice() {
 	readOptions();
 
 	emit(connectedDevice(m_isConnected));
+
+	auto sensor = SensorTemperature{ 0, 0, 0, 0, enCameraTemperatureStatus::STABILISED };
+	emit(s_sensorTemperatureChanged(sensor));
 }
 
 void MockCamera::disconnectDevice() {

--- a/BrillouinAcquisition/src/Devices/Cameras/MockCamera.cpp
+++ b/BrillouinAcquisition/src/Devices/Cameras/MockCamera.cpp
@@ -1,0 +1,116 @@
+#include "stdafx.h"
+#include "MockCamera.h"
+
+/*
+ * Public definitions
+ */
+
+MockCamera::~MockCamera() {
+	std::lock_guard<std::mutex> lockGuard(m_mutex);
+}
+
+/*
+ * Public slots
+ */
+
+void MockCamera::connectDevice() {
+	if (!m_isConnected) {
+		m_isConnected = true;
+	}
+
+	emit(connectedDevice(m_isConnected));
+}
+
+void MockCamera::disconnectDevice() {
+	if (m_isConnected) {
+		m_isConnected = false;
+	}
+
+	emit(connectedDevice(m_isConnected));
+}
+
+void MockCamera::setSettings(CAMERA_SETTINGS settings) {
+	m_settings = settings;
+	// Read back the settings
+	readSettings();
+}
+
+void MockCamera::startPreview() {
+	// don't do anything if an acquisition is running
+	if (m_isAcquisitionRunning) {
+		return;
+	}
+	m_isPreviewRunning = true;
+	m_stopPreview = false;
+	getImageForPreview();
+
+	emit(s_previewRunning(m_isPreviewRunning));
+}
+
+void MockCamera::stopPreview() {
+	m_isPreviewRunning = false;
+	m_stopPreview = false;
+	emit(s_previewRunning(m_isPreviewRunning));
+}
+
+void MockCamera::startAcquisition(CAMERA_SETTINGS settings) {
+	std::lock_guard<std::mutex> lockGuard(m_mutex);
+	// check if currently a preview is running and stop it in case
+	if (m_isPreviewRunning) {
+		stopPreview();
+		m_wasPreviewRunning = true;
+	} else {
+		m_wasPreviewRunning = false;
+	}
+	setSettings(settings);
+
+	emit(s_previewBufferSettingsChanged());
+
+	m_isAcquisitionRunning = true;
+	emit(s_acquisitionRunning(m_isAcquisitionRunning));
+}
+
+void MockCamera::stopAcquisition() {
+	m_isAcquisitionRunning = false;
+	emit(s_acquisitionRunning(m_isAcquisitionRunning));
+
+	// Restart the preview if it was running before the acquisition
+	if (m_wasPreviewRunning) {
+		startPreview();
+	}
+}
+
+void MockCamera::getImageForAcquisition(unsigned char* buffer, bool preview) {
+	std::lock_guard<std::mutex> lockGuard(m_mutex);
+
+	acquireImage(buffer);
+
+	if (preview && buffer != nullptr) {
+		// write image to preview buffer
+		memcpy(m_previewBuffer->m_buffer->getWriteBuffer(), buffer, m_settings.roi.bytesPerFrame);
+		m_previewBuffer->m_buffer->m_usedBuffers->release();
+	}
+}
+
+/*
+ * Private definitions
+ */
+
+int MockCamera::acquireImage(unsigned char* buffer) {
+
+	// Copy data to provided buffer
+	//if (data != NULL && buffer != nullptr) {
+	//	memcpy(buffer, data, m_settings.roi.bytesPerFrame);
+	//	return 1;
+	//}
+	return 0;
+}
+
+void MockCamera::readOptions() {
+	emit(optionsChanged(m_options));
+}
+
+void MockCamera::readSettings() {
+	// emit signal that settings changed
+	emit(settingsChanged(m_settings));
+}

--- a/BrillouinAcquisition/src/Devices/Cameras/MockCamera.h
+++ b/BrillouinAcquisition/src/Devices/Cameras/MockCamera.h
@@ -22,11 +22,14 @@ public slots:
 	void stopAcquisition() override;
 	void getImageForAcquisition(unsigned char* buffer, bool preview = true) override;
 
+	void setCalibrationExposureTime(double exposureTime);
+
 private:
 	int acquireImage(unsigned char* buffer) override;
 
 	void readOptions() override;
 	void readSettings() override;
+	void preparePreview();
 };
 
 #endif // MOCKCAMERA_H

--- a/BrillouinAcquisition/src/Devices/Cameras/MockCamera.h
+++ b/BrillouinAcquisition/src/Devices/Cameras/MockCamera.h
@@ -1,0 +1,32 @@
+#ifndef MOCKCAMERA_H
+#define MOCKCAMERA_H
+
+#include "Camera.h"
+
+class MockCamera : public Camera {
+	Q_OBJECT
+
+public:
+	MockCamera() noexcept {};
+	~MockCamera();
+
+public slots:
+	void init() override {};
+	void connectDevice() override;
+	void disconnectDevice() override;
+
+	void setSettings(CAMERA_SETTINGS) override;
+	void startPreview() override;
+	void stopPreview() override;
+	void startAcquisition(CAMERA_SETTINGS) override;
+	void stopAcquisition() override;
+	void getImageForAcquisition(unsigned char* buffer, bool preview = true) override;
+
+private:
+	int acquireImage(unsigned char* buffer) override;
+
+	void readOptions() override;
+	void readSettings() override;
+};
+
+#endif // MOCKCAMERA_H

--- a/BrillouinAcquisition/src/Devices/Cameras/MockCamera.h
+++ b/BrillouinAcquisition/src/Devices/Cameras/MockCamera.h
@@ -27,6 +27,9 @@ public slots:
 private:
 	int acquireImage(unsigned char* buffer) override;
 
+	template <typename T>
+	int acquireImage(unsigned char* buffer);
+
 	void readOptions() override;
 	void readSettings() override;
 	void preparePreview();

--- a/BrillouinAcquisition/src/Devices/Cameras/cameraParameters.h
+++ b/BrillouinAcquisition/src/Devices/Cameras/cameraParameters.h
@@ -34,6 +34,7 @@ struct CAMERA_READOUT {
 	std::wstring cycleMode{ L"Continuous" };
 	std::wstring triggerMode{ L"Software" };
 	std::wstring preAmpGain{ L"16-bit (low noise & high well capacity)" };
+	std::string dataType{ "unsigned char" };	// type of the data
 };
 
 struct CAMERA_SETTINGS {


### PR DESCRIPTION
Implements a mock camera class to simplify debugging.

Closes #158.

Todo:
- [x] Implement camera image / pattern
- [x] Implement correct binning behaviour
- [x] Respect data type acquisition setting