### PR TITLE
Fix writing scale calibration for modes other than Brillouin

### DIFF
--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/AcquisitionMode.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/AcquisitionMode.cpp
@@ -29,11 +29,11 @@ void AcquisitionMode::setAcquisitionStatus(ACQUISITION_STATUS status) {
 	emit(s_acquisitionStatus(m_status));
 }
 
-void AcquisitionMode::writeScaleCalibration(std::unique_ptr <StorageWrapper>& storage) {
+void AcquisitionMode::writeScaleCalibration(std::unique_ptr <StorageWrapper>& storage, ACQUISITION_MODE mode) {
 	auto scaleCalibration = (*m_scanControl)->getScaleCalibration();
 
 	auto positionStage = (*m_scanControl)->getPosition(PositionType::STAGE);
 	auto positionScanner = (*m_scanControl)->getPosition(PositionType::SCANNER);
 
-	storage->setScaleCalibration({ scaleCalibration, positionStage, positionScanner });
+	storage->setScaleCalibration(mode, { scaleCalibration, positionStage, positionScanner });
 }

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/AcquisitionMode.h
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/AcquisitionMode.h
@@ -40,7 +40,7 @@ protected:
 
 	void setAcquisitionStatus(ACQUISITION_STATUS);
 
-	void writeScaleCalibration(std::unique_ptr <StorageWrapper>& storage);
+	void writeScaleCalibration(std::unique_ptr <StorageWrapper>& storage, ACQUISITION_MODE mode);
 
 	ACQUISITION_STATUS m_status{ ACQUISITION_STATUS::DISABLED };
 	Acquisition* m_acquisition{ nullptr };

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Brillouin.cpp
@@ -443,7 +443,7 @@ void Brillouin::acquire(std::unique_ptr <StorageWrapper>& storage) {
 
 	auto resolutionXout = storage->getResolution("x");
 
-	writeScaleCalibration(storage);
+	writeScaleCalibration(storage, ACQUISITION_MODE::BRILLOUIN);
 
 	/*
 	 * Update the positions vector

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/Fluorescence.cpp
@@ -262,7 +262,7 @@ void Fluorescence::acquire(std::unique_ptr <StorageWrapper>& storage, std::vecto
 		}
 	}
 
-	writeScaleCalibration(storage);
+	writeScaleCalibration(storage, ACQUISITION_MODE::FLUORESCENCE);
 
 	QMetaObject::invokeMethod(
 		storage.get(),

--- a/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.cpp
+++ b/BrillouinAcquisition/src/Acquisition/AcquisitionModes/ODT.cpp
@@ -325,7 +325,7 @@ void ODT::acquire(std::unique_ptr <StorageWrapper> & storage) {
 	(*m_ODTControl)->setVoltage(m_acqSettings.voltages[0]);
 	Sleep(100);
 
-	writeScaleCalibration(storage);
+	writeScaleCalibration(storage, ACQUISITION_MODE::ODT);
 
 	ACQ_VOLTAGES voltages;
 


### PR DESCRIPTION
This fixes writing the scale calibration data for modes other than Brillouin.

Closes #162.