### PR TITLE
Fix regressions

### DIFF
--- a/BrillouinAcquisition/src/Devices/Cameras/Camera.cpp
+++ b/BrillouinAcquisition/src/Devices/Cameras/Camera.cpp
@@ -18,11 +18,6 @@ CAMERA_SETTINGS Camera::getSettings() {
  */
 
 void Camera::setSettings(CAMERA_SETTINGS settings) {
-	// Don't do anything if an acquisition is running.
-	if (m_isAcquisitionRunning) {
-		return;
-	}
-
 	// Check that pixel encoding is valid
 	if (std::find(m_options.pixelEncodings.begin(), m_options.pixelEncodings.end(), settings.readout.pixelEncoding) ==
 		m_options.pixelEncodings.end() && !m_options.pixelEncodings.empty()

--- a/BrillouinAcquisition/src/Devices/Cameras/MockCamera.cpp
+++ b/BrillouinAcquisition/src/Devices/Cameras/MockCamera.cpp
@@ -171,11 +171,6 @@ void MockCamera::readSettings() {
 }
 
 void MockCamera::applySettings(const CAMERA_SETTINGS& settings) {
-	// Don't do anything if an acquisition is running.
-	if (m_isAcquisitionRunning) {
-		return;
-	}
-
 	m_settings = settings;
 
 	auto binning{ 1 };

--- a/BrillouinAcquisition/src/Devices/Cameras/PointGrey.cpp
+++ b/BrillouinAcquisition/src/Devices/Cameras/PointGrey.cpp
@@ -238,11 +238,6 @@ void PointGrey::readSettings() {
 }
 
 void PointGrey::applySettings(const CAMERA_SETTINGS& settings) {
-	// Don't do anything if an acquisition is running.
-	if (m_isAcquisitionRunning) {
-		return;
-	}
-
 	m_settings = settings;
 
 	if (m_settings.readout.pixelEncoding == L"Raw8") {

--- a/BrillouinAcquisition/src/Devices/Cameras/andor.cpp
+++ b/BrillouinAcquisition/src/Devices/Cameras/andor.cpp
@@ -238,11 +238,6 @@ void Andor::readSettings() {
 }
 
 void Andor::applySettings(const CAMERA_SETTINGS& settings) {
-	// Don't do anything if an acquisition is running.
-	if (m_isAcquisitionRunning) {
-		return;
-	}
-
 	m_settings = settings;
 
 	if (m_settings.readout.pixelEncoding == L"Mono12") {

--- a/BrillouinAcquisition/src/Devices/Cameras/pvcamera.cpp
+++ b/BrillouinAcquisition/src/Devices/Cameras/pvcamera.cpp
@@ -378,11 +378,6 @@ void PVCamera::readSettings() {
 }
 
 void PVCamera::applySettings(const CAMERA_SETTINGS& settings) {
-	// Don't do anything if an acquisition is running.
-	if (m_isAcquisitionRunning) {
-		return;
-	}
-
 	// We have to update the options when we change port and speed
 	auto updateOptions{ false };
 	if (m_settings.readout.pixelReadoutRate != settings.readout.pixelReadoutRate) {

--- a/BrillouinAcquisition/src/Devices/Cameras/pvcamera.cpp
+++ b/BrillouinAcquisition/src/Devices/Cameras/pvcamera.cpp
@@ -103,8 +103,11 @@ void PVCamera::stopAcquisition() {
 
 void PVCamera::getImageForAcquisition(std::byte* buffer, bool preview) {
 	std::lock_guard<std::mutex> lockGuard(m_mutex);
-
-	auto i_retCode = PVCam::pl_exp_start_seq(m_camera, m_acquisitionBuffer);
+	
+	// Only write to acquisition buffer if it is valid
+	if (m_acquisitionBuffer) {
+		auto i_retCode = PVCam::pl_exp_start_seq(m_camera, m_acquisitionBuffer);
+	}
 
 	{
 		std::unique_lock<std::mutex> lock(g_EofMutex);
@@ -113,16 +116,18 @@ void PVCamera::getImageForAcquisition(std::byte* buffer, bool preview) {
 			waitTime = (waitTime < 5) ? 5 : waitTime;
 			g_EofCond.wait_for(lock, std::chrono::seconds(waitTime), [this]() {
 				return (g_EofFlag);
-				});
+			});
 		}
 		g_EofFlag = false; // Reset flag
 	}
-
-	memcpy(buffer, m_acquisitionBuffer, m_settings.roi.bytesPerFrame);
-
+	
+	// Only read from acquisition buffer if it is valid
+	if (m_acquisitionBuffer) {
+		memcpy(buffer, m_acquisitionBuffer, m_settings.roi.bytesPerFrame);
+	}
 	PVCam::pl_exp_finish_seq(m_camera, m_acquisitionBuffer, 0);
 
-	if (preview) {
+	if (preview && m_acquisitionBuffer) {
 		// write image to preview buffer
 		memcpy(m_previewBuffer->m_buffer->getWriteBuffer(), buffer, m_settings.roi.bytesPerFrame);
 		m_previewBuffer->m_buffer->m_usedBuffers->release();
@@ -723,9 +728,24 @@ void PVCamera::prepareAcquisition(const CAMERA_SETTINGS& settings) {
 	// Disable temperature timer if it is running
 	stopTempTimer();
 
+
 	PVCam::pl_cam_register_callback_ex3(m_camera, PVCam::PL_CALLBACK_EOF, (void*)acquisitionCallback, (void*)this);
 	
 	setSettings(settings);
+
+	// For acquisition we use sequential mode and have to set this up explicitly
+	auto camSettings = getCamSettings();
+	auto bufferSize = PVCam::uns32{};
+	PVCam::pl_exp_setup_seq(
+		m_camera,
+		1,
+		1,
+		&camSettings,
+		PVCam::TIMED_MODE,
+		1e3 * m_settings.exposureTime,
+		&bufferSize
+	);
+	m_settings.roi.bytesPerFrame = bufferSize;
 
 	if (m_acquisitionBuffer) {
 		delete[] m_acquisitionBuffer;

--- a/BrillouinAcquisition/src/Devices/Cameras/uEyeCam.cpp
+++ b/BrillouinAcquisition/src/Devices/Cameras/uEyeCam.cpp
@@ -264,11 +264,6 @@ void uEyeCam::readSettings() {
 }
 
 void uEyeCam::applySettings(const CAMERA_SETTINGS& settings) {
-	// Don't do anything if an acquisition is running.
-	if (m_isAcquisitionRunning) {
-		return;
-	}
-
 	m_settings = settings;
 
 	// If the preview is currently running, stop it and apply the settings.


### PR DESCRIPTION
- Camera settings couldn't be set during acquisition (necessary for calibration)
- PVCam would ocassionally crash, since I now correctly delete a buffer, but the camera was still writing to it