### PR TITLE
Correct mirror positions for FOB setup

### DIFF
--- a/BrillouinAcquisition/src/Devices/ScanControls/NIDAQ.h
+++ b/BrillouinAcquisition/src/Devices/ScanControls/NIDAQ.h
@@ -88,8 +88,8 @@ private:
 	double m_gearBoxRatio{ 67 };	// [1]  ratio of the gear box
 	double m_pitch{ 1 };			// [mm] pitch of the lead screw
 
-	double m_mirrorStart{ 0.0 };
-	double m_mirrorEnd{ 14.0 };
+	double m_mirrorStart{ 2.0 };
+	double m_mirrorEnd{ 18.0 };
 
 	// moveable filter mounts
 	FilterMount* m_exFilter{ nullptr };


### PR DESCRIPTION
Sometimes the movable mirror motor forgets its current position. Today this happened again, so that the currently used values don't work anymore.

I now use the values which are correct after the mirror motor was homed. So if this happens again, home the mirror motor and the values should be ok again.