### PR TITLE
Fix commonprops and error handling

### DIFF
--- a/BrillouinAcquisition/src/Devices/ScanControls/ZeissMTB.cpp
+++ b/BrillouinAcquisition/src/Devices/ScanControls/ZeissMTB.cpp
@@ -78,12 +78,20 @@ void ZeissMTB::setPosition(POINT2 position) {
 	// We have to subtract the position of the scanner to get the position of the stage.
 	auto positionStage = position - m_positionScanner;
 	if (abs(m_positionStage.x - positionStage.x) > 1e-6) {
-		m_positionStage.x = positionStage.x;
-		success = m_stageX->SetPosition(m_positionStage.x, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		try {
+			m_positionStage.x = positionStage.x;
+			success = m_stageX->SetPosition(m_positionStage.x, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		} catch (_com_error& e) {
+			qDebug() << "Error setting stage X position:" << e.ErrorMessage();
+		}
 	}
 	if (abs(m_positionStage.y - positionStage.y) > 1e-6) {
-		m_positionStage.y = positionStage.y;
-		success = m_stageY->SetPosition(m_positionStage.y, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		try {
+			m_positionStage.y = positionStage.y;
+			success = m_stageY->SetPosition(m_positionStage.y, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		} catch (_com_error& e) {
+			qDebug() << "Error setting stage Y position:" << e.ErrorMessage();
+		}
 	}
 	calculateCurrentPositionBounds(POINT3{ position.x, position.y, m_positionFocus });
 	announcePositions();
@@ -96,8 +104,12 @@ void ZeissMTB::setPosition(POINT3 position) {
 	}
 	// Only set position if it has changed
 	if (abs(m_positionFocus - position.z) > 1e-6) {
-		m_positionFocus = position.z;
-		success = m_ObjectiveFocus->SetPosition(m_positionFocus, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		try {
+			m_positionFocus = position.z;
+			success = m_ObjectiveFocus->SetPosition(m_positionFocus, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		} catch (_com_error& e) {
+			qDebug() << "Error setting focus position:" << e.ErrorMessage();
+		}
 	}
 	setPosition(POINT2{ position.x, position.y });
 }
@@ -108,12 +120,20 @@ void ZeissMTB::movePosition(POINT2 distance) {
 		return;
 	}
 	if (abs(distance.x) > 1e-6) {
-		m_positionStage.x += distance.x;
-		success = m_stageX->SetPosition(distance.x, "µm", (MTBCmdSetModes)(MTBCmdSetModes::MTBCmdSetModes_Synchronous | MTBCmdSetModes::MTBCmdSetModes_Relative), 500);
+		try {
+			m_positionStage.x += distance.x;
+			success = m_stageX->SetPosition(distance.x, "µm", (MTBCmdSetModes)(MTBCmdSetModes::MTBCmdSetModes_Synchronous | MTBCmdSetModes::MTBCmdSetModes_Relative), 500);
+		} catch (_com_error& e) {
+			qDebug() << "Error moving stage X:" << e.ErrorMessage();
+		}
 	}
 	if (abs(distance.y) > 1e-6) {
-		m_positionStage.y += distance.y;
-		success = m_stageY->SetPosition(distance.y, "µm", (MTBCmdSetModes)(MTBCmdSetModes::MTBCmdSetModes_Synchronous | MTBCmdSetModes::MTBCmdSetModes_Relative), 500);
+		try {
+			m_positionStage.y += distance.y;
+			success = m_stageY->SetPosition(distance.y, "µm", (MTBCmdSetModes)(MTBCmdSetModes::MTBCmdSetModes_Synchronous | MTBCmdSetModes::MTBCmdSetModes_Relative), 500);
+		} catch (_com_error& e) {
+			qDebug() << "Error moving stage Y:" << e.ErrorMessage();
+		}
 	}
 	calculateCurrentPositionBounds();
 	announcePositions();
@@ -122,11 +142,19 @@ void ZeissMTB::movePosition(POINT2 distance) {
 POINT3 ZeissMTB::getPosition(PositionType positionType) {
 	// Update the positions from the hardware
 	if (m_stageX && m_stageY) {
-		m_positionStage.x = m_stageX->GetPosition("µm");
-		m_positionStage.y = m_stageY->GetPosition("µm");
+		try {
+			m_positionStage.x = m_stageX->GetPosition("µm");
+			m_positionStage.y = m_stageY->GetPosition("µm");
+		} catch (_com_error& e) {
+			qDebug() << "Error getting stage position:" << e.ErrorMessage();
+		}
 	}
 	if (m_ObjectiveFocus) {
-		m_positionFocus = m_ObjectiveFocus->GetPosition("µm");
+		try {
+			m_positionFocus = m_ObjectiveFocus->GetPosition("µm");
+		} catch (_com_error& e) {
+			qDebug() << "Error getting focus position:" << e.ErrorMessage();
+		}
 	}
 
 	// Return the current position
@@ -324,14 +352,24 @@ bool ZeissMTB::setElement(IMTBChangerPtr element, int position) {
 	if (!element) {
 		return false;
 	}
-	return element->SetPosition(position, MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+	try {
+		return element->SetPosition(position, MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+	} catch (_com_error& e) {
+		qDebug() << "Error setting element position:" << e.ErrorMessage();
+		return false;
+	}
 }
 
 int ZeissMTB::getElement(IMTBChangerPtr element) {
 	if (!element) {
 		return -1;
 	}
-	return element->GetPosition();
+	try {
+		return element->GetPosition();
+	} catch (_com_error& e) {
+		qDebug() << "Error getting element position:" << e.ErrorMessage();
+		return -1;
+	}
 }
 
 void ZeissMTB::setBeamBlock(int position) {
@@ -415,13 +453,22 @@ void ZeissMTB::setLamp(int voltage, bool block) {
 	}
 	if (voltage > 100) voltage = 100;
 	if (voltage < 0) voltage = 0;
-	// Set the voltage
-	auto success = m_Lamp->SetPosition(voltage, "%", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+	try {
+		// Set the voltage
+		auto success = m_Lamp->SetPosition(voltage, "%", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+	} catch (_com_error& e) {
+		qDebug() << "Error setting lamp voltage:" << e.ErrorMessage();
+	}
 }
 
 double ZeissMTB::getLamp() {
 	if (!m_Lamp) {
 		return 0.0;
 	}
-	return m_Lamp->GetPosition("%");
+	try {
+		return m_Lamp->GetPosition("%");
+	} catch (_com_error& e) {
+		qDebug() << "Error getting lamp voltage:" << e.ErrorMessage();
+		return 0.0;
+	}
 }

--- a/BrillouinAcquisition/src/Devices/ScanControls/ZeissMTB_Erlangen.cpp
+++ b/BrillouinAcquisition/src/Devices/ScanControls/ZeissMTB_Erlangen.cpp
@@ -79,12 +79,20 @@ void ZeissMTB_Erlangen::setPosition(POINT2 position) {
 	// We have to subtract the position of the scanner to get the position of the stage.
 	auto positionStage = position - m_positionScanner;
 	if (abs(m_positionStage.x - positionStage.x) > 1e-6) {
-		m_positionStage.x = positionStage.x;
-		success = m_stageX->SetPosition(m_positionStage.x, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		try {
+			m_positionStage.x = positionStage.x;
+			success = m_stageX->SetPosition(m_positionStage.x, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		} catch (_com_error& e) {
+			qDebug() << "Error setting stage X position:" << e.ErrorMessage();
+		}
 	}
 	if (abs(m_positionStage.y - positionStage.y) > 1e-6) {
-		m_positionStage.y = positionStage.y;
-		success = m_stageY->SetPosition(m_positionStage.y, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		try {
+			m_positionStage.y = positionStage.y;
+			success = m_stageY->SetPosition(m_positionStage.y, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		} catch (_com_error& e) {
+			qDebug() << "Error setting stage Y position:" << e.ErrorMessage();
+		}
 	}
 	calculateCurrentPositionBounds(POINT3{ position.x, position.y, m_positionFocus });
 	announcePositions();
@@ -97,8 +105,12 @@ void ZeissMTB_Erlangen::setPosition(POINT3 position) {
 	}
 	// Only set position if it has changed
 	if (abs(m_positionFocus - position.z) > 1e-6) {
-		m_positionFocus = position.z;
-		success = m_ObjectiveFocus->SetPosition(m_positionFocus, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		try {
+			m_positionFocus = position.z;
+			success = m_ObjectiveFocus->SetPosition(m_positionFocus, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		} catch (_com_error& e) {
+			qDebug() << "Error setting focus position:" << e.ErrorMessage();
+		}
 	}
 	setPosition(POINT2{ position.x, position.y });
 }
@@ -109,12 +121,20 @@ void ZeissMTB_Erlangen::movePosition(POINT2 distance) {
 		return;
 	}
 	if (abs(distance.x) > 1e-6) {
-		m_positionStage.x += distance.x;
-		success = m_stageX->SetPosition(distance.x, "µm", (MTBCmdSetModes)(MTBCmdSetModes::MTBCmdSetModes_Synchronous | MTBCmdSetModes::MTBCmdSetModes_Relative), 500);
+		try {
+			m_positionStage.x += distance.x;
+			success = m_stageX->SetPosition(distance.x, "µm", (MTBCmdSetModes)(MTBCmdSetModes::MTBCmdSetModes_Synchronous | MTBCmdSetModes::MTBCmdSetModes_Relative), 500);
+		} catch (_com_error& e) {
+			qDebug() << "Error moving stage X:" << e.ErrorMessage();
+		}
 	}
 	if (abs(distance.y) > 1e-6) {
-		m_positionStage.y += distance.y;
-		success = m_stageY->SetPosition(distance.y, "µm", (MTBCmdSetModes)(MTBCmdSetModes::MTBCmdSetModes_Synchronous | MTBCmdSetModes::MTBCmdSetModes_Relative), 500);
+		try {
+			m_positionStage.y += distance.y;
+			success = m_stageY->SetPosition(distance.y, "µm", (MTBCmdSetModes)(MTBCmdSetModes::MTBCmdSetModes_Synchronous | MTBCmdSetModes::MTBCmdSetModes_Relative), 500);
+		} catch (_com_error& e) {
+			qDebug() << "Error moving stage Y:" << e.ErrorMessage();
+		}
 	}
 	calculateCurrentPositionBounds();
 	announcePositions();
@@ -122,11 +142,19 @@ void ZeissMTB_Erlangen::movePosition(POINT2 distance) {
 
 POINT3 ZeissMTB_Erlangen::getPosition(PositionType positionType) {
 	if (m_stageX && m_stageY) {
-		m_positionStage.x = m_stageX->GetPosition("µm");
-		m_positionStage.y = m_stageY->GetPosition("µm");
+		try {
+			m_positionStage.x = m_stageX->GetPosition("µm");
+			m_positionStage.y = m_stageY->GetPosition("µm");
+		} catch (_com_error& e) {
+			qDebug() << "Error getting stage position:" << e.ErrorMessage();
+		}
 	}
 	if (m_ObjectiveFocus) {
-		m_positionFocus = m_ObjectiveFocus->GetPosition("µm");
+		try {
+			m_positionFocus = m_ObjectiveFocus->GetPosition("µm");
+		} catch (_com_error& e) {
+			qDebug() << "Error getting focus position:" << e.ErrorMessage();
+		}
 	}
 
 	// Return the current position
@@ -327,14 +355,24 @@ bool ZeissMTB_Erlangen::setElement(IMTBChangerPtr element, int position) {
 	if (!element) {
 		return false;
 	}
-	return element->SetPosition(position, MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+	try {
+		return element->SetPosition(position, MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+	} catch (_com_error& e) {
+		qDebug() << "Error setting element position:" << e.ErrorMessage();
+		return false;
+	}
 }
 
 int ZeissMTB_Erlangen::getElement(IMTBChangerPtr element) {
 	if (!element) {
 		return -1;
 	}
-	return element->GetPosition();
+	try {
+		return element->GetPosition();
+	} catch (_com_error& e) {
+		qDebug() << "Error getting element position:" << e.ErrorMessage();
+		return -1;
+	}
 }
 
 void ZeissMTB_Erlangen::setReflector(int position, bool block) {

--- a/BrillouinAcquisition/src/Devices/ScanControls/ZeissMTB_Erlangen2.cpp
+++ b/BrillouinAcquisition/src/Devices/ScanControls/ZeissMTB_Erlangen2.cpp
@@ -74,12 +74,20 @@ void ZeissMTB_Erlangen2::setPosition(POINT2 position) {
 	// We have to subtract the position of the scanner to get the position of the stage.
 	auto positionStage = position - m_positionScanner;
 	if (abs(m_positionStage.x - positionStage.x) > 1e-6) {
-		m_positionStage.x = positionStage.x;
-		success = m_stageX->SetPosition(m_positionStage.x, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		try {
+			m_positionStage.x = positionStage.x;
+			success = m_stageX->SetPosition(m_positionStage.x, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		} catch (_com_error& e) {
+			qDebug() << "Error setting stage X position:" << e.ErrorMessage();
+		}
 	}
 	if (abs(m_positionStage.y - positionStage.y) > 1e-6) {
-		m_positionStage.y = positionStage.y;
-		success = m_stageY->SetPosition(m_positionStage.y, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		try {
+			m_positionStage.y = positionStage.y;
+			success = m_stageY->SetPosition(m_positionStage.y, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		} catch (_com_error& e) {
+			qDebug() << "Error setting stage Y position:" << e.ErrorMessage();
+		}
 	}
 	calculateCurrentPositionBounds(POINT3{ position.x, position.y, m_positionFocus });
 	announcePositions();
@@ -92,8 +100,12 @@ void ZeissMTB_Erlangen2::setPosition(POINT3 position) {
 	}
 	// Only set position if it has changed
 	if (abs(m_positionFocus - position.z) > 1e-6) {
-		m_positionFocus = position.z;
-		success = m_ObjectiveFocus->SetPosition(m_positionFocus, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		try {
+			m_positionFocus = position.z;
+			success = m_ObjectiveFocus->SetPosition(m_positionFocus, "µm", MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+		} catch (_com_error& e) {
+			qDebug() << "Error setting focus position:" << e.ErrorMessage();
+		}
 	}
 	setPosition(POINT2{ position.x, position.y });
 }
@@ -104,12 +116,20 @@ void ZeissMTB_Erlangen2::movePosition(POINT2 distance) {
 		return;
 	}
 	if (abs(distance.x) > 1e-6) {
-		m_positionStage.x += distance.x;
-		success = m_stageX->SetPosition(distance.x, "µm", (MTBCmdSetModes)(MTBCmdSetModes::MTBCmdSetModes_Synchronous | MTBCmdSetModes::MTBCmdSetModes_Relative), 500);
+		try {
+			m_positionStage.x += distance.x;
+			success = m_stageX->SetPosition(distance.x, "µm", (MTBCmdSetModes)(MTBCmdSetModes::MTBCmdSetModes_Synchronous | MTBCmdSetModes::MTBCmdSetModes_Relative), 500);
+		} catch (_com_error& e) {
+			qDebug() << "Error moving stage X:" << e.ErrorMessage();
+		}
 	}
 	if (abs(distance.y) > 1e-6) {
-		m_positionStage.y += distance.y;
-		success = m_stageY->SetPosition(distance.y, "µm", (MTBCmdSetModes)(MTBCmdSetModes::MTBCmdSetModes_Synchronous | MTBCmdSetModes::MTBCmdSetModes_Relative), 500);
+		try {
+			m_positionStage.y += distance.y;
+			success = m_stageY->SetPosition(distance.y, "µm", (MTBCmdSetModes)(MTBCmdSetModes::MTBCmdSetModes_Synchronous | MTBCmdSetModes::MTBCmdSetModes_Relative), 500);
+		} catch (_com_error& e) {
+			qDebug() << "Error moving stage Y:" << e.ErrorMessage();
+		}
 	}
 	calculateCurrentPositionBounds();
 	announcePositions();
@@ -117,11 +137,19 @@ void ZeissMTB_Erlangen2::movePosition(POINT2 distance) {
 
 POINT3 ZeissMTB_Erlangen2::getPosition(PositionType positionType) {
 	if (m_stageX && m_stageY) {
-		m_positionStage.x = m_stageX->GetPosition("µm");
-		m_positionStage.y = m_stageY->GetPosition("µm");
+		try {
+			m_positionStage.x = m_stageX->GetPosition("µm");
+			m_positionStage.y = m_stageY->GetPosition("µm");
+		} catch (_com_error& e) {
+			qDebug() << "Error getting stage position:" << e.ErrorMessage();
+		}
 	}
 	if (m_ObjectiveFocus) {
-		m_positionFocus = m_ObjectiveFocus->GetPosition("µm");
+		try {
+			m_positionFocus = m_ObjectiveFocus->GetPosition("µm");
+		} catch (_com_error& e) {
+			qDebug() << "Error getting focus position:" << e.ErrorMessage();
+		}
 	}
 
 	// Return the current position
@@ -307,14 +335,24 @@ bool ZeissMTB_Erlangen2::setElement(IMTBChangerPtr element, int position) {
 	if (!element) {
 		return false;
 	}
-	return element->SetPosition(position, MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+	try {
+		return element->SetPosition(position, MTBCmdSetModes::MTBCmdSetModes_Synchronous, 500);
+	} catch (_com_error& e) {
+		qDebug() << "Error setting element position:" << e.ErrorMessage();
+		return false;
+	}
 }
 
 int ZeissMTB_Erlangen2::getElement(IMTBChangerPtr element) {
 	if (!element) {
 		return -1;
 	}
-	return element->GetPosition();
+	try {
+		return element->GetPosition();
+	} catch (_com_error& e) {
+		qDebug() << "Error getting element position:" << e.ErrorMessage();
+		return -1;
+	}
 }
 
 void ZeissMTB_Erlangen2::setReflector(int position, bool block) {

--- a/commonProps/ThirdPartyPaths.props
+++ b/commonProps/ThirdPartyPaths.props
@@ -63,9 +63,7 @@
       $(EXTERNAL_UNWRAP2_DIR);
     </ThirdPartyLibDirs>
 
-    <ThirdPartyLibs>
-      $(ANDOR_SDK_DIR)\atcorem.lib;
-      $(ANDOR_SDK_DIR)\atutilitym.lib;
+    <ThirdPartyLibsCommon>
       libfftw3-3.lib;
       $(POINT_GREY_DIR)\lib64\vs2015\FlyCapture2_v140.lib;
       $(IDS_UEYE_DIR)\Develop\Lib\uEye_api_64.lib;
@@ -77,7 +75,7 @@
       Thorlabs.MotionControl.KCube.DCServo.lib;
       Thorlabs.MotionControl.KCube.Solenoid.lib;
       pvcam64.lib;
-    </ThirdPartyLibs>
+    </ThirdPartyLibsCommon>
   </PropertyGroup>
 
   <!-- Differences specific to Debug build -->
@@ -87,7 +85,9 @@
     </ThirdPartyIncludes>
 
     <ThirdPartyLibs>
-      $(ThirdPartyLibs);
+      $(ThirdPartyLibsCommon);
+      $(ANDOR_SDK_DIR)\atcorem.lib;
+      $(ANDOR_SDK_DIR)\atutilitym.lib;
       <!-- OpenCV debug DLL file -->
       opencv_world470d.lib;
     </ThirdPartyLibs>
@@ -100,7 +100,9 @@
     </ThirdPartyIncludes>
 
     <ThirdPartyLibs>
-      $(ThirdPartyLibs);
+      $(ThirdPartyLibsCommon);
+      $(ANDOR_SDK_DIR)\atcore.lib;
+      $(ANDOR_SDK_DIR)\atutility.lib;
       <!-- OpenCV normal DLL file -->
       opencv_world470.lib;
     </ThirdPartyLibs>
@@ -111,8 +113,6 @@
   <PropertyGroup Label="PostBuildCmdsCommon">
     <!-- Common copy commands for both Debug and Release -->
     <PostBuildCmdsCommon>
-			copy "$(ANDOR_SDK_DIR)\atcore.dll" $(TargetDir)
-			copy "$(ANDOR_SDK_DIR)\atutility.dll" $(TargetDir)
 			copy "$(ANDOR_SDK_DIR)\atblkbx.dll" $(TargetDir)
 			copy "$(ANDOR_SDK_DIR)\atcl_bitflow.dll" $(TargetDir)
 			copy "$(ANDOR_SDK_DIR)\atdevregcam.dll" $(TargetDir)
@@ -137,6 +137,8 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug' and '$(Platform)'=='x64'">
     <!-- Additional copy commands for Debug -->
     <PostBuildCmdsDebug>
+      copy "$(ANDOR_SDK_DIR)\atcorem.dll" $(TargetDir)
+      copy "$(ANDOR_SDK_DIR)\atutilitym.dll" $(TargetDir)
       copy "$(OPENCV_DIR)\x64\vc16\bin\opencv_world470d.dll" $(TargetDir)
     </PostBuildCmdsDebug>
   </PropertyGroup>
@@ -144,6 +146,8 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release' and '$(Platform)'=='x64'">
     <!-- Additional copy commands for Release, if needed -->
     <PostBuildCmdsRelease>
+      copy "$(ANDOR_SDK_DIR)\atcore.dll" $(TargetDir)
+      copy "$(ANDOR_SDK_DIR)\atutility.dll" $(TargetDir)
       copy "$(OPENCV_DIR)\x64\vc16\bin\opencv_world470.dll" $(TargetDir)
 			copy "$(IDS_UEYE_DIR)\USB driver package\ueye_api_64.dll" $(TargetDir)
 			copy "$(SystemRoot)\System32\pvcam64.dll" $(TargetDir)


### PR DESCRIPTION
This PR aims to fix compilation errors due to the wrong CommonProps configuration and error handling.
- properly set Andor SDK libraries for `debug` and `release` configurations
- explicitly handling `_com_error` errors